### PR TITLE
Use gtk_init_check

### DIFF
--- a/CppApplication_1/dbase.c
+++ b/CppApplication_1/dbase.c
@@ -620,9 +620,12 @@ runprog() {
     //linea añadida porque cambiaba el punto por comma
     if (!gtk_iniciado) {
       gtk_disable_setlocale();
-      gtk_init(&argc, &argv); 
+      if (!gtk_init_check(&argc, &argv)) {
+        fprintf(stderr, "No se pudo inicializar GTK; ejecute en modo texto.\n");
+        return -1;  /* o manejarlo de otra manera */
+      }
     }
-    
+
     gtk_iniciado = 1;
     
     indice = atoi(buff2[1]);


### PR DESCRIPTION
## Summary
- add fallback initialization using `gtk_init_check`

## Testing
- `gcc -v -w -g -o miprograma run.c variables.c dinamic.c bt.c graficos.c dbase.c err.c minieditor.c lex.yy.c grammar.tab.c \`pkg-config --cflags --libs gtk+-2.0\` -lm`
- `./miprograma`

------
https://chatgpt.com/codex/tasks/task_e_68409c901fcc83319e9df0a789afc554