### PR TITLE
Fix GTK init in runall

### DIFF
--- a/CppApplication_1/minieditor.c
+++ b/CppApplication_1/minieditor.c
@@ -1846,7 +1846,10 @@ void runall() {
 
     if (!gtk_iniciado) {
         gtk_disable_setlocale();
-        gtk_init(&argc, &argv);
+        if (!gtk_init_check(&argc, &argv)) {
+            fprintf(stderr, "No se pudo inicializar GTK; ejecute en modo texto.\n");
+            return;      /* or other appropriate handling */
+        }
     }
 
     gtk_iniciado = 1;


### PR DESCRIPTION
## Summary
- improve initialization in `runall` using `gtk_init_check`

## Testing
- `make -C CppApplication_1` *(fails: cairo.h missing)*

------
https://chatgpt.com/codex/tasks/task_e_684fe6e8b7b08331a25c6dead3c3e7a7